### PR TITLE
Fix command in README to run test suite with ghci

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ stack test --fast
 To execute the test-suite faster while developing, do:
 ``` bash
 chmod go-w .ghci .
-stack exec ghci
+stack exec ghci test/Spec.hs
 ```
 
 and then at the `ghci` prompt do:


### PR DESCRIPTION
I was not able to run the tests via ghci as documented, so I looked at the hspec documentation and found this to work instead: https://github.com/hspec/hspec-example#ghci
