### PR TITLE
Default to servant 0.9 which comes with lts-7.12

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -27,7 +27,7 @@ executables:
 
 dependencies:
   - base
-  - servant == 0.6.*
+  - servant
   - servant-server
   - transformers
   - aeson

--- a/src/App.hs
+++ b/src/App.hs
@@ -41,8 +41,6 @@ server =
   getItems :<|>
   getItemById
 
-type Handler = ExceptT ServantErr IO
-
 getItems :: Handler [Item]
 getItems = return [exampleItem]
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,3 @@
-resolver: nightly-2016-04-14
+resolver: lts-7.12
 packages:
   - '.'
-extra-deps:
-  - servant-0.6.1
-  - servant-client-0.6.1
-  - servant-server-0.6.1


### PR DESCRIPTION
Subj, I assume it's reasonable to default to whatever version stackage lts provides and avoid duplicated mentions of the version number.