### PR TITLE
WIP: adding nix expression; fixing a few issues for LTS 12.24, still broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .stack-work/
 example-servant-minimal.cabal
+
+# Editor files:
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
 .stack-work/
 example-servant-minimal.cabal
-
-# Editor files:
-*~

--- a/README.md
+++ b/README.md
@@ -43,3 +43,11 @@ Then you can query the server like this:
 ``` bash
 curl localhost:3000/item
 ```
+
+### Nix
+
+Using Nix or NixOS, you can run `nix-shell stack.nix` before
+following the above instructions. But please note, you'll want
+to edit `stack.nix` and comment out large visual studio code
+dependencies if you don't want to pull these in 
+(`hiepkgs.hies`, `vscode`).

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Then you can query the server like this:
 curl localhost:3000/item
 ```
 
+To do thorough testing, as done by Travis CI, do:
+
+``` bash
+stack test --no-terminal --pedantic
+```
+
 ### Nix
 
 If you are using Nix or NixOS, you can run `nix-shell stack.nix` before

--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ curl localhost:3000/item
 
 ### Nix
 
-Using Nix or NixOS, you can run `nix-shell stack.nix` before
+If you are using Nix or NixOS, you can run `nix-shell stack.nix` before
 following the above instructions. But please note, you'll want
 to edit `stack.nix` and comment out large visual studio code
 dependencies if you don't want to pull these in 
-(`hiepkgs.hies`, `vscode`).
+(`hiepkgs.hies`, `vscode`). Also note, you will need to add the
+`--nix` flag to each of the `stack` commands. For instance,
+`stack test --nix --fast`.

--- a/src/App.hs
+++ b/src/App.hs
@@ -5,7 +5,6 @@
 
 module App where
 
-import           Control.Monad.Trans.Except
 import           Data.Aeson
 import           GHC.Generics
 import           Network.Wai
@@ -47,7 +46,7 @@ getItems = return [exampleItem]
 getItemById :: Integer -> Handler Item
 getItemById = \ case
   0 -> return exampleItem
-  _ -> throwE err404
+  _ -> throwError err404
 
 exampleItem :: Item
 exampleItem = Item 0 "example item"

--- a/stack.nix
+++ b/stack.nix
@@ -1,0 +1,34 @@
+######
+#
+# Author: Brandon Barker
+#
+######
+
+with import <nixpkgs> { };
+let
+  hiepkgs = import (builtins.fetchTarball {
+    # Note: please configure cachix, or this will take a while:
+    # https://hie-nix.cachix.org/
+    name = "example-servant-minimal";
+    url = https://github.com/domenkozar/hie-nix/tarball/a7ef4c4ceef1dbf46aabff68a4b9bd86d41d0886;
+    # Hash obtained using `nix-prefetch-url --unpack <url>`
+    sha256 = "1hx449l001jc6ijn9zxx30zr1xr2nnrv7qmhpsqwj8wp6s4zyxw8";
+  }) {};
+in stdenv.mkDerivation {
+  name = "cow-streamer-stack";
+  buildInputs = [
+    #
+    # Editor stuff
+    #
+    hiepkgs.hies
+    vscode
+    
+    cabal-install
+    gmp
+    haskellPackages.Stack
+  ];
+  shellHook = ''
+    export LD_LIBRARY_PATH=${gmp}/lib:$LD_LIBRARY_PATH
+  '';  
+}
+

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,7 @@
-resolver: lts-8.12
+resolver: lts-12.24
 packages:
   - '.'
+
+nix:
+  enable: true
+  packages: [gmp, zlib]

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,5 +3,4 @@ packages:
   - '.'
 
 nix:
-  enable: true
   packages: [gmp, zlib]

--- a/test/AppSpec.hs
+++ b/test/AppSpec.hs
@@ -2,7 +2,7 @@
 module AppSpec where
 
 import           Control.Exception (throwIO)
-import           Network.HTTP.Client (Manager, newManager, defaultManagerSettings)
+import           Network.HTTP.Client (Manager, newManager, defaultManagerSettings, responseStatus)
 import           Network.HTTP.Types
 import           Network.Wai (Application)
 import           Network.Wai.Handler.Warp
@@ -35,7 +35,7 @@ withClient x innerSpec =
     flip aroundWith innerSpec $ \ action -> \ manager -> do
       testWithApplication x $ \ port -> do
         let baseUrl = BaseUrl Http "localhost" port ""
-        action (ClientEnv manager baseUrl)
+        action (ClientEnv manager baseUrl Nothing)
 
 type Host = (Manager, BaseUrl)
 

--- a/test/AppSpec.hs
+++ b/test/AppSpec.hs
@@ -17,6 +17,7 @@ getItems :: ClientM [Item]
 getItem :: Integer -> ClientM Item
 getItems :<|> getItem = client itemApi
 
+shouldNotOccur :: IO ()
 shouldNotOccur = False `shouldBe` True
 
 spec :: Spec


### PR DESCRIPTION
Also subsumes #7; still need to fix the following issue when running `stack test --no-terminal --pedantic`:

```                                                                                                                                                                                   
/home/brandon/workspace/example-servant-minimal/test/AppSpec.hs:30:9: error:                                                                                                       
    * No instance for (GHC.Exception.Exception                                                                                                                                     
                         (http-client-0.5.14:Network.HTTP.Client.Types.Response body0))                                                                                            
        arising from a use of `shouldThrow'                                                                                                                                        
    * In a stmt of a 'do' block:                                                                                                                                                   
        try env (getItem 42)                                                                                                                                                       
          `shouldThrow` (\ e -> responseStatus e == notFound404)                                                                                                                   
      In the expression:                                                                                                                                                           
        do try env (getItem 42)                                                                                                                                                    
             `shouldThrow` (\ e -> responseStatus e == notFound404)                                                                                                                
      In the second argument of `($)', namely                                                                                                                                      
        `\ env                                                                                                                                                                     
           -> do try env (getItem 42)                                                                                                                                              
                   `shouldThrow` (\ e -> responseStatus e == notFound404)'                                                                                                         
   |                                                                                                                                                                               
30 |         try env (getItem 42) `shouldThrow` (\ e -> responseStatus e == notFound404)                                                                                           
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                           
                           
```

Sorry, it may be easier for a more advanced haskeller to tell what is going on here.